### PR TITLE
Harmonize style of questions in stack.sh

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -179,7 +179,7 @@ buildDockerComposeConfigFileIfNeeded() {
 
         # Ask for storage mountpoints
         read -p "[?] Path to your ezpublish storages on host [/mnt/\$USER]: " storage_local_path
-        storage_local_path=${storage_local_path:-/mnt/\$USER/}
+        storage_local_path=${storage_local_path:-/mnt/\$USER}
 
         echo "Your local storage folder will be mounted in '/mnt/$USER' inside containers"
         echo "(Don't forget to symlink your storage in your ez5 instance after first run)"
@@ -209,7 +209,7 @@ buildDockerComposeConfigFileIfNeeded() {
         echo "export DOCKER_VARNISH_VCL_FILE=$vcl_filepath" >> $DOCKER_COMPOSE_CONFIG_FILE
         echo "export DOCKER_SOLR_CONF_PATH=$solr_conf_path" >> $DOCKER_COMPOSE_CONFIG_FILE
         echo "export DOCKER_STORAGE_LOCAL_PATH=$storage_local_path" >> $DOCKER_COMPOSE_CONFIG_FILE
-        echo "export DOCKER_STORAGE_MOUNT_POINT=/mnt/\$USER/" >> $DOCKER_COMPOSE_CONFIG_FILE
+        echo "export DOCKER_STORAGE_MOUNT_POINT=/mnt/\$USER" >> $DOCKER_COMPOSE_CONFIG_FILE
 
         #Configure PHP version
         configurePhpVersion


### PR DESCRIPTION
This PR contains a bunch of changes to the wording and typesetting of `echo` and `read` commands in `stack.sh`, with the goal of improving style consistency and readability. The best way to test it is to get the modified version from https://github.com/fvsch/ezdocker-stack and run `./stack.sh` to see if the result feels cleaner.

Changes:

* "Usage":
    - use pipe characters, which are more common for options IMO, instead of slashes (which can suggest a path);
    - update the command list to remove `build`, and add `web_server_switch` and `update`.

* Default values:
    - When asking for a folder path, some questions and some corresponding default values in the script printed a default value with a trailing slash, and others had no trailing slash. I tried removing all trailing slashes and given the way they are used in `docker-compose-template.yml` and that my tests worked fine, it seems to be okay to settle on this "no trailing slash" style for messages and default paths.

* Punctuation:
    - Removed spaces before `!` and `:` in sentences (English typography rules), fixing a few inconsistencies.
    - Fixed a few inconsistencies with ellipsis, always using a space before `...`. Technically ellipsis should be the `…` character, but ` ... ` (with spaces and three dots) is common with some publishers, and used in the output of docker-compose, so we're consistent with that.
    - Limited usage of `...` to messages that mean "we're doing some work" (including stopping the script).
    - Changed `ERROR ! lowercase message` to `ERROR: lowercase message`. `ERROR! Capitalized message` would have been correct too, but I picked the colon option because the all-caps `ERROR` is strong enough to not need an exclamation point IMO.
    - For errors that result in aborting the setup, the message pattern is always `ERROR: <the message>. Aborting ..."

* User input messages:
    - Added a `[?] ` in front of each `read` message. It helps differentiating between input requests and information/error output. I wasn't 100% sure about this, but after testing a few options (including no prefix), I find that it works really well.
    - Made some message terser, so that message + input can fit in <120 characters most of the time.
    - All questions now follow the same structure.

Structure for input messages looks like (underscore represents the user's cursor):

```
[?] Some request: _
[?] Other request [default value]: _
[?] What about this one? [option1], option2, option3: _
```

With this format:
- User input is always after a semicolon. (Or a question mark for the question "What is your main project name?", but this one could be changed to a declarative form for consistency.)
- The default value is always indicated by square brackets (a convention I've seen a few times, e.g. in `composer init`).
